### PR TITLE
Support for Intro/Outro options.

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -29,6 +29,8 @@ module.exports = function(grunt) {
       useStrict: true,
       banner: null,
       footer: null,
+	  intro: null,
+	  outro: null,
       sourceMap: false,
       sourceMapFile: null,
       sourceMapRelativePaths: false
@@ -70,6 +72,8 @@ module.exports = function(grunt) {
           useStrict: options.useStrict,
           banner: options.banner,
           footer: options.footer,
+		  intro: options.intro,
+		  outro: options.outro,
           sourceMap: options.sourceMap,
           sourceMapFile: sourceMapFile
         });

--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -29,8 +29,8 @@ module.exports = function(grunt) {
       useStrict: true,
       banner: null,
       footer: null,
-	  intro: null,
-	  outro: null,
+      intro: null,
+      outro: null,
       sourceMap: false,
       sourceMapFile: null,
       sourceMapRelativePaths: false
@@ -72,8 +72,8 @@ module.exports = function(grunt) {
           useStrict: options.useStrict,
           banner: options.banner,
           footer: options.footer,
-		  intro: options.intro,
-		  outro: options.outro,
+          intro: options.intro,
+          outro: options.outro,
           sourceMap: options.sourceMap,
           sourceMapFile: sourceMapFile
         });


### PR DESCRIPTION
Rollup has support for intro and outro [block](https://github.com/rollup/rollup/wiki/JavaScript-API#introoutro).
The grunt plugin was just not passing the options. Now it does.