### PR TITLE
[tasks/rollup.js] add option `context` and `moduleContext`

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -64,7 +64,9 @@ module.exports = function(grunt) {
       return rollup.rollup({
         entry: entry,
         external: options.external,
-        plugins: plugins
+        plugins: plugins,
+        context: options.context,
+        moduleContext: options.moduleContext
       }).then(function(bundle) {
 
         var sourceMapFile = options.sourceMapFile;


### PR DESCRIPTION
Support `context` and `moduleContext` option which mentioned [here](https://github.com/rollup/rollup/wiki/JavaScript-API#context).

PS: I don't think it's a good way to pass option like what `tasks/rollup.js` do. It really makes less expansibility.
