### PR TITLE
Rollup should be added as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,15 @@
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0"
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "rollup": "^0.48.2"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=0.4.0",
+    "rollup": "^0.48.2"
   },
   "keywords": [
     "gruntplugin",
     "rollup"
-  ],
-  "dependencies": {
-    "rollup": "0.47.4"
-  }
+  ]
 }


### PR DESCRIPTION
Added rollup as peer dependency so user can select a newer version if needed.