### PR TITLE
Add support for "interop" flag

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -39,7 +39,8 @@ module.exports = function(grunt) {
       sourceMap: false,
       sourceMapFile: null,
       sourceMapRelativePaths: false,
-      treeshake: true
+      treeshake: true,
+      interop: true
     });
 
     var promises = this.files.map(function(f) {
@@ -76,7 +77,8 @@ module.exports = function(grunt) {
         onwarn: options.onwarn,
         preferConst: options.preferConst,
         pureExternalModules: options.pureExternalModules,
-        treeshake: options.treeshake
+        treeshake: options.treeshake,
+        interop: options.interop
       }).then(function(bundle) {
 
         var sourceMapFile = options.sourceMapFile;


### PR DESCRIPTION
I've added support for the "interop" flag:
##  interop

```Boolean whether or not to add an 'interop block'. By default (interop: true), for safety's sake, Rollup will assign any external dependencies' default exports to a separate variable if it's necessary to distinguish between default and named exports. This generally only applies if your external dependencies were transpiled (for example with Babel) – if you're sure you don't need it, you can save a few bytes with interop: false.```