### PR TITLE
update options to remove deprecation warnings

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
         preferConst: options.preferConst,
         pureExternalModules: options.pureExternalModules,
         treeshake: options.treeshake,
-        interop: options.interop
+        output: { interop: options.interop }
       }).then(function(bundle) {
 
         var sourceMapFile = options.sourceMapFile;
@@ -87,10 +87,10 @@ module.exports = function(grunt) {
         }
 
         return bundle.generate({
+          amd: { id: options.moduleId },
           format: options.format,
           exports: options.exports,
           paths: options.paths,
-          moduleId: options.moduleId,
           name: options.moduleName,
           globals: options.globals,
           indent: options.indent,


### PR DESCRIPTION
Setting `moduleId` has moved to `amd.id`, see: 
https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0420

Setting `interop` has moved to `output.interop`, see:
https://github.com/rollup/rollup/blob/f21547a1e38b9918b4f42f8350b94eb7fb324925/src/utils/deprecateOptions.ts#L34