### PR TITLE
Update options to remove deprecation warnings

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
       format: 'es',
       exports: 'auto',
       moduleId: null,
+      moduleDefine: 'define',
       moduleName: null,
       globals: {},
       indent: true,
@@ -77,8 +78,7 @@ module.exports = function(grunt) {
         onwarn: options.onwarn,
         preferConst: options.preferConst,
         pureExternalModules: options.pureExternalModules,
-        treeshake: options.treeshake,
-        interop: options.interop
+        treeshake: options.treeshake
       }).then(function(bundle) {
 
         var sourceMapFile = options.sourceMapFile;
@@ -90,6 +90,10 @@ module.exports = function(grunt) {
           format: options.format,
           exports: options.exports,
           paths: options.paths,
+          amd: {
+            id: options.moduleId,
+            define: options.moduleDefine
+          },
           moduleId: options.moduleId,
           name: options.moduleName,
           globals: options.globals,
@@ -100,7 +104,8 @@ module.exports = function(grunt) {
           intro: options.intro,
           outro: options.outro,
           sourcemap: options.sourceMap,
-          sourcemapFile: sourceMapFile
+          sourcemapFile: sourceMapFile,
+          interop: options.interop
         });
       }).then(function(result) {
         var code = result.code;


### PR DESCRIPTION
Setting moduleId has moved to amd.id, see:
https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0420

Setting interop has moved to output.interop, see:
https://github.com/rollup/rollup/blob/f21547a1e38b9918b4f42f8350b94eb7fb324925/src/utils/deprecateOptions.ts#L34