### PR TITLE
Modify logic for deciding to use "dir" vs "file" in rollup output options. 

### DIFF
--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -70,6 +70,7 @@ module.exports = (grunt) => {
             preferConst: false,
             strict: true,
             systemNullSetters: false,
+            forceDirUse: false
         });
 
         const promises = current.files.map((files) => {
@@ -185,8 +186,10 @@ module.exports = (grunt) => {
                 systemNullSetters,
             }))(options);
 
-            const isMultipleInput = Array.isArray(files.src) && files.src.length > 1;
-
+            const isMultipleFiles = Array.isArray(files.src) && files.src.length > 1;
+            const isDestFile = files.dest.indexOf(".") > 0;
+            const isMultipleInput = options.forceDirUse || isMultipleFiles || isDestFile;
+            
             return rollup
                 .rollup({
                     ...inputOptions,

--- a/tasks/rollup.js
+++ b/tasks/rollup.js
@@ -70,7 +70,7 @@ module.exports = (grunt) => {
             preferConst: false,
             strict: true,
             systemNullSetters: false,
-            forceDirUse: false
+            forceDirUse: false,
         });
 
         const promises = current.files.map((files) => {
@@ -189,7 +189,6 @@ module.exports = (grunt) => {
             const isMultipleFiles = Array.isArray(files.src) && files.src.length > 1;
             const isDestFile = files.dest.indexOf(".") > 0;
             const isMultipleInput = options.forceDirUse || isMultipleFiles || isDestFile;
-            
             return rollup
                 .rollup({
                     ...inputOptions,


### PR DESCRIPTION
Information: Modify the logic for deciding to use dir vs file in rollups output options.
Kind: bugfix?  maybe feature.

Description:  I'm not sure if this is a bug or not, but I've been unable to get this plugin to use the "dir" output option instead of "file", it seemed to me that files.src.length was always one, regardless of how many source files I used, or how I formatted my files section of the config.  I left this code in place, in case it's not broken and I just lack the proper understanding of how to do it.

Even if this part isn't a bug, I figured we could use some extra options in this area, so I added an options entry to force it to DIR, and tried a different auto detect method: looking for a dot in the destination path to see if it's a file, if it's a directory, then use DIR.  This makes way more sense to me than changing the output options based on the number of input files. 

Not sure if it matters what I'm trying to do with it, but this change allows me to easily use Rollups code splitting features.  Here's my relevant config, with the current version this would cause an error, but with this change it works:
```
    rollup: {
      options: {
        plugins: ...,
        manualChunks(id) {
          if (id.includes('node_modules')) {
            return 'vendor';
          }
          if (id.includes("subModule")) {
            return "subModule";
          }
        }
      },
      main: {
        files: [{
          expand: true,
          cwd: 'build/flattened/',
          src: ['main.js'],
          dest: 'build/rolluped/',
          filter: 'isFile',
        }],
      },
    },
```

